### PR TITLE
support for skipping Pandora stations

### DIFF
--- a/remotes/pandora.js
+++ b/remotes/pandora.js
@@ -103,6 +103,22 @@ exec(function(){
             icon: 'fast-forward',
             hash: 'skip',
             leapmotion: 'swipe-left'
+          },
+          {
+            press: function () {
+              var $current = $('.stationListItem.selected');
+              // Get the next station
+              var $next = $current.next('.stationListItem');
+              // If there wasn't a next one, go back to the first.
+              if( $next.length == 0 ) {
+                  // Go to the beginning; skip the shuffle button.
+                  $next = $current.prevAll('.stationListItem').last().next();
+              }
+              $next.click();
+            },
+            icon: 'fast-forward',
+            hash: 'skip-station',
+            leapmotion: 'swipe-left'
           }
         ]
       },


### PR DESCRIPTION
Support added for skipping stations in Pandora. Skips to the next
station or to the top of the list if it reached the bottom. Skips over
the shuffle button, because when shuffle was pressed it changed the
display of the stations and prevented further skipping. I used the
fast-forward icon, but need to come up with a better icon.
